### PR TITLE
docs: rebrand LambdaTest to TestMu AI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# Run Selenium Tests With MSTest On LambdaTest
+# Run Selenium Tests With MSTest — TestMu AI (Formerly LambdaTest)
 
 ![image](https://user-images.githubusercontent.com/70570645/171443386-68376fc1-489e-4930-9186-07a30de636ce.png)
 
 <p align="center">
-  <a href="https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Blog</a>
+  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Blog</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Docs</a>
+  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Docs</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Learning Hub</a>
+  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Learning Hub</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Newsletter</a>
+  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Newsletter</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.lambdatest.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Certifications</a>
+  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Certifications</a>
   &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/c/LambdaTest" target="_bank">YouTube</a>
+  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
 </p>
 &emsp;
 &emsp;
 &emsp;
 
-*Learn how to use MSTest framework to configure and run your C# automation testing scripts on the LambdaTest platform*
+*Learn how to use MSTest framework to configure and run your C# automation testing scripts on the TestMu AI platform*
 
 [<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
 
@@ -42,16 +42,16 @@ Before you can start performing **MSTest** automation testing with **Selenium**,
 
 ### Installing Selenium Dependencies And Tutorial Repo
 
-**Step 1:** Clone the LambdaTest’s MSTest-Selenium-Sample repository and navigate to the code directory as shown below:
+**Step 1:** Clone the TestMu AI’s MSTest-Selenium-Sample repository and navigate to the code directory as shown below:
 
 ```csharp
 git clone https://github.com/LambdaTest/MSTest-Selenium-Sample
 cd MSTest-Selenium-Sample
 ```
 ### Setting up Your Authentication 
-Make sure you have your LambdaTest credentials with you to run test automation scripts with C# on LambdaTest Selenium Grid. You can get these credentials from the [LambdaTest Automation Dashboard](https://automation.lambdatest.com/login?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample) or by your LambdaTest Profile.
+Make sure you have your TestMu AI credentials with you to run test automation scripts with C# on TestMu AI Selenium Grid. You can get these credentials from the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/login?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample) or by your TestMu AI Profile.
 
-**Step 2:** Set LambdaTest Username and Access Key in environment variables.
+**Step 2:** Set TestMu AI Username and Access Key in environment variables.
 
  **For Linux/macOS**:
  
@@ -69,7 +69,7 @@ Make sure you have your LambdaTest credentials with you to run test automation s
 
 ### Configuration of Your Test Capabilities
 
-**Step 4:** In the test script, you need to update your test capabilities. In this code, we are passing browser, browser version, and operating system information, along with LambdaTest Selenium grid capabilities via capabilities object. The capabilities object in the above code are defined as:
+**Step 4:** In the test script, you need to update your test capabilities. In this code, we are passing browser, browser version, and operating system information, along with TestMu AI Selenium grid capabilities via capabilities object. The capabilities object in the above code are defined as:
 
 ```csharp
 DesiredCapabilities capabilities = new DesiredCapabilities();
@@ -78,7 +78,7 @@ DesiredCapabilities capabilities = new DesiredCapabilities();
             capabilities.SetCapability(CapabilityType.Platform, "Windows 10");
 ```
 
-**Note:** You can generate capabilities for your test requirements with the help of **[Desired Capabilitiy Generator](https://www.lambdatest.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)**.
+**Note:** You can generate capabilities for your test requirements with the help of **[Desired Capabilitiy Generator](https://www.testmuai.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)**.
 
 ### Executing The Test
 
@@ -97,24 +97,24 @@ DesiredCapabilities capabilities = new DesiredCapabilities();
 ```csharp
 dotnet test MS-Test-Cross-Browser.csproj
 ```
-Your results would be displayed on the test console and on the LambdaTest Automation Dashboard.
+Your results would be displayed on the test console and on the TestMu AI Automation Dashboard.
 
 ## Running Your Parallel Tests Using MSTest Testing Framework
 
-To run parallel tests, open Visual Studio and go to **Test Explorer** and then click on **Run All** tests to execute the tests. Your results would be displayed on the test console and on the LambdaTest Automation Dashboard.
+To run parallel tests, open Visual Studio and go to **Test Explorer** and then click on **Run All** tests to execute the tests. Your results would be displayed on the test console and on the TestMu AI Automation Dashboard.
 
 ## Testing Locally Hosted Or Privately Hosted Projects
 
-You can test your locally hosted or privately hosted projects with LambdaTest Selenium grid using LambdaTest Tunnel. All you would have to do is set up an SSH tunnel using tunnel and pass toggle `tunnel = True` via desired capabilities. LambdaTest Tunnel establishes a secure SSH protocol based tunnel that allows you in testing your locally hosted or privately hosted pages, even before they are live.
+You can test your locally hosted or privately hosted projects with TestMu AI Selenium grid using TestMu AI Tunnel. All you would have to do is set up an SSH tunnel using tunnel and pass toggle `tunnel = True` via desired capabilities. TestMu AI Tunnel establishes a secure SSH protocol based tunnel that allows you in testing your locally hosted or privately hosted pages, even before they are live.
 
-Refer our [LambdaTest Tunnel documentation](https://www.lambdatest.com/support/docs/testing-locally-hosted-pages/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample) for more information.
+Refer our [TestMu AI Tunnel documentation](https://www.testmuai.com/support/docs/testing-locally-hosted-pages/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample) for more information.
 
-Here’s how you can establish LambdaTest Tunnel.
+Here’s how you can establish TestMu AI Tunnel.
 
 Download the binary file of:
-* [LambdaTest Tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
-* [LambdaTest Tunnel for macOS](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
-* [LambdaTest Tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
+* [TestMu AI Tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
+* [TestMu AI Tunnel for macOS](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
+* [TestMu AI Tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
 
 Open command prompt and navigate to the binary folder.
 
@@ -128,7 +128,7 @@ So if your user name is lambdatest@example.com and key is 123456, the command wo
 ```bash
 LT --user lambdatest@example.com --key 123456
 ```
-Once you are able to connect **LambdaTest Tunnel** successfully, you would just have to pass on tunnel capabilities in the code shown below :
+Once you are able to connect **TestMu AI Tunnel** successfully, you would just have to pass on tunnel capabilities in the code shown below :
 
 **Tunnel Capability**
 
@@ -138,67 +138,57 @@ DesiredCapabilities capabilities = new DesiredCapabilities();
 ```
 ## Additional Links
 
-* [Advanced Configuration for Capabilities](https://www.lambdatest.com/support/docs/selenium-automation-capabilities/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [How to test locally hosted apps](https://www.lambdatest.com/support/docs/testing-locally-hosted-pages/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [How to integrate LambdaTest with CI/CD](https://www.lambdatest.com/support/docs/integrations-with-ci-cd-tools/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+* [Advanced Configuration for Capabilities](https://www.testmuai.com/support/docs/selenium-automation-capabilities/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+* [How to test locally hosted apps](https://www.testmuai.com/support/docs/testing-locally-hosted-pages/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+* [How to integrate TestMu AI with CI/CD](https://www.testmuai.com/support/docs/integrations-with-ci-cd-tools/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
 
 ## Tutorials 📙
 
 Check out our latest tutorials on MSTest automation testing 👇
 
-* [NUnit vs. XUnit vs. MSTest: Comparing Unit Testing Frameworks In C#](https://www.lambdatest.com/blog/nunit-vs-xunit-vs-mstest/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [Selenium MSTest Tutorial: Setup Selenium WebDriver For MSTest Framework In C#](https://www.lambdatest.com/blog/setting-selenium-webdriver-for-mstest/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [Most Complete MSTest Framework Tutorial Using .Net Core](https://www.lambdatest.com/blog/most-complete-mstest-framework-tutorial-using-net-core-2/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [MSTest Tutorial: Parameterized Tests For Selenium Testing](https://www.lambdatest.com/blog/mstest-tutorial-parameterized-tests-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [MSTest‌ ‌Tutorial:‌ ‌Running‌ ‌First‌ ‌Selenium‌ ‌Automation‌ ‌Script‌](https://www.lambdatest.com/blog/mstest-tutorial-running-first-selenium-automation-script/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [MSTest Tutorial: Environment Setup For Selenium Testing](https://www.lambdatest.com/blog/mstest-tutorial-environment-setup-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+* [NUnit vs. XUnit vs. MSTest: Comparing Unit Testing Frameworks In C#](https://www.testmuai.com/blog/nunit-vs-xunit-vs-mstest/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+* [Selenium MSTest Tutorial: Setup Selenium WebDriver For MSTest Framework In C#](https://www.testmuai.com/blog/setting-selenium-webdriver-for-mstest/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+* [Most Complete MSTest Framework Tutorial Using .Net Core](https://www.testmuai.com/blog/most-complete-mstest-framework-tutorial-using-net-core-2/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+* [MSTest Tutorial: Parameterized Tests For Selenium Testing](https://www.testmuai.com/blog/mstest-tutorial-parameterized-tests-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+* [MSTest‌ ‌Tutorial:‌ ‌Running‌ ‌First‌ ‌Selenium‌ ‌Automation‌ ‌Script‌](https://www.testmuai.com/blog/mstest-tutorial-running-first-selenium-automation-script/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+* [MSTest Tutorial: Environment Setup For Selenium Testing](https://www.testmuai.com/blog/mstest-tutorial-environment-setup-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
 
 For video tutorials on Selenium MSTest, please refer to our [MSTest Tutorial Playlist](https://www.youtube.com/playlist?list=PLZMWkkQEwOPlT7o9t3IN162KY3eG7K7TN). ▶️
 
-Subscribe To Our [LambdaTest YouTube Channel 🔔](https://www.youtube.com/c/LambdaTest) and keep up-to-date on the latest video tutorial around software testing world.
+Subscribe To Our [TestMu AI YouTube Channel 🔔](https://www.youtube.com/@TestMuAI) and keep up-to-date on the latest video tutorial around software testing world.
 
 ## Documentation & Resources :books:
 
       
-Visit the following links to learn more about LambdaTest's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
 
-* [LambdaTest Documentation](https://www.lambdatest.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [LambdaTest Blog](https://www.lambdatest.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [LambdaTest Learning Hub](https://www.lambdatest.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)    
+* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)    
 
-## LambdaTest Community :busts_in_silhouette:
+## TestMu AI Community :busts_in_silhouette:
 
-The [LambdaTest Community](https://community.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
 
-## What's New At LambdaTest ❓
+## What's New At TestMu AI ❓
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/) 
-      
-## About LambdaTest
+To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
 
-[LambdaTest](https://www.lambdatest.com?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample) is a leading test execution and orchestration platform that is fast, reliable, scalable, and secure. It allows users to run both manual and automated testing of web and mobile apps across 3000+ different browsers, operating systems, and real device combinations. Using LambdaTest, businesses can ensure quicker developer feedback and hence achieve faster go to market. Over 500 enterprises and 1 Million + users across 130+ countries rely on LambdaTest for their testing needs.    
+## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
 
-### Features
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
-* Run Selenium, Cypress, Puppeteer, Playwright, and Appium automation tests across 3000+ real desktop and mobile environments.
-* Real-time cross browser testing on 3000+ environments.
-* Test on Real device cloud
-* Blazing fast test automation with HyperExecute
-* Accelerate testing, shorten job times and get faster feedback on code changes with Test At Scale.
-* Smart Visual Regression Testing on cloud
-* 120+ third-party integrations with your favorite tool for CI/CD, Project Management, Codeless Automation, and more.
-* Automated Screenshot testing across multiple browsers in a single click.
-* Local testing of web and mobile apps.
-* Online Accessibility Testing across 3000+ desktop and mobile browsers, browser versions, and operating systems.
-* Geolocation testing of web and mobile apps across 53+ countries.
-* LT Browser - for responsive testing across 50+ pre-installed mobile, tablets, desktop, and laptop viewports
+Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-    
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+**🔄 Our Rebrand Journey**
 
-      
-## We are here to help you :headphones:
+We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-* Got a query? we are available 24x7 to help. [Contact Us](mailto:support@lambdatest.com)
-* For more info, visit - [LambdaTest](https://www.lambdatest.com/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+**✨ Specialties**
 
+- 🤖 AI-Native Test Execution (Formerly LambdaTest)
+- ⚡ Autonomous Test Automation
+- 🌐 Cross-Browser & Mobile Testing
+- 📊 Unified Quality Intelligence
+
+👉 Find [LambdaTest's New Home](https://www.testmuai.com/).

--- a/README.md
+++ b/README.md
@@ -180,13 +180,19 @@ To stay updated with the latest features and product add-ons, visit [Changelog](
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
-**🔄 Our Rebrand Journey**
+### 🔄 Our Rebrand Journey
+
+In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
+
+As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
+
+Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
 
-**🔭 Explore TestMu AI**
+### 🔭 Explore TestMu AI
 
 The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
 

--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_
 
 To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
 
-## 🚀 [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/)
+## 🚀 LambdaTest is Now TestMu AI
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, LambdaTest has officially rebranded to TestMu AI. We have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
+👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
 
 Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
 
@@ -184,11 +184,15 @@ Whether you have been part of the LambdaTest community for years or are just dis
 
 We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
 
-**✨ Specialties**
-
-- 🤖 AI-Native Test Execution (Formerly LambdaTest)
-- ⚡ Autonomous Test Automation
-- 🌐 Cross-Browser & Mobile Testing
-- 📊 Unified Quality Intelligence
-
 👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
+
+**🔭 Explore TestMu AI**
+
+The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
+
+- [KaneAI](https://www.testmuai.com/kane-ai/)
+- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
+- [HyperExecute](https://www.testmuai.com/hyperexecute/)
+- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
+- [Pricing](https://www.testmuai.com/pricing/)
+- [Documentation](https://www.testmuai.com/support/docs/)

--- a/README.md
+++ b/README.md
@@ -1,204 +1,111 @@
-# Run Selenium Tests With MSTest — TestMu AI (Formerly LambdaTest)
-
-![image](https://user-images.githubusercontent.com/70570645/171443386-68376fc1-489e-4930-9186-07a30de636ce.png)
+# Run Selenium Tests with C# and MSTest on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
-  <a href="https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Blog</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Docs</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Learning Hub</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/newsletter/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Newsletter</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.testmuai.com/certifications/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample" target="_bank">Certifications</a>
-  &nbsp; &#8901; &nbsp;
-  <a href="https://www.youtube.com/@TestMuAI" target="_bank">YouTube</a>
+  <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
+  <a href="https://www.nuget.org/packages/MSTest.TestFramework/"><img src="https://img.shields.io/nuget/v/MSTest.TestFramework.svg?style=for-the-badge&labelColor=000000" alt="MSTest version"></a>
+  <a href="https://community.testmuai.com/"><img src="https://img.shields.io/badge/Join%20the%20community-blueviolet.svg?style=for-the-badge&labelColor=000000" alt="Community"></a>
 </p>
-&emsp;
-&emsp;
-&emsp;
 
-*Learn how to use MSTest framework to configure and run your C# automation testing scripts on the TestMu AI platform*
+## Getting Started
 
-[<img height="58" width="200" src="https://user-images.githubusercontent.com/70570645/171866795-52c11b49-0728-4229-b073-4b704209ddde.png">](https://accounts.lambdatest.com/register?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+[TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-## Table Of Contents
+With TestMu AI (Formerly LambdaTest), you can run MSTest Selenium tests in C# across real browsers and operating systems. This sample shows how to configure C# MSTest Selenium tests to run on the TestMu AI cloud.
 
-* [Pre-requisites](#pre-requisites)
-* [Run Your First Test](#run-your-first-test)
-* [Parallel Testing With MSTest](#running-your-parallel-tests-using-mstest-testing-framework)
-* [Local Testing With MSTest](#testing-locally-hosted-or-privately-hosted-projects)
+- [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
+- Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.
 
-## Prerequisites
+### Prerequisites
 
-Before you can start performing **MSTest** automation testing with **Selenium**, you would need to:
+- .NET Framework or .NET Core
+- Visual Studio
+- A TestMu AI (Formerly LambdaTest) account with your username and access key
 
-* Download and Install **Selenium WebDriver** from its [official website](https://www.selenium.dev/downloads/).
-* Make sure you have latest version of C#.
-* **.Net** framework to deliver guidelines while developing a range of application using C#.
-* Download [Selenium WebDriver Language Binding](https://www.selenium.dev/downloads/) for C# and extract them to appropriate folder.
-* A [.NET Core SDK](https://dotnet.microsoft.com/en-us/download) of 3.0.0.
+### Setup
 
-### Installing Selenium Dependencies And Tutorial Repo
+Clone and install dependencies:
 
-**Step 1:** Clone the TestMu AI’s MSTest-Selenium-Sample repository and navigate to the code directory as shown below:
-
-```csharp
-git clone https://github.com/LambdaTest/MSTest-Selenium-Sample
-cd MSTest-Selenium-Sample
-```
-### Setting up Your Authentication 
-Make sure you have your TestMu AI credentials with you to run test automation scripts with C# on TestMu AI Selenium Grid. You can get these credentials from the [TestMu AI Automation Dashboard](https://automation.lambdatest.com/login?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample) or by your TestMu AI Profile.
-
-**Step 2:** Set TestMu AI Username and Access Key in environment variables.
-
- **For Linux/macOS**:
- 
- `export LT_USERNAME="YOUR_USERNAME" export LT_ACCESS_KEY="YOUR ACCESS KEY"`
- 
- **For Windows**:
- 
- `set LT_USERNAME="YOUR_USERNAME" set LT_ACCESS_KEY="YOUR ACCESS KEY"`
-
-## Run Your First Test 
-
->**Test Scenario**: This MSTest Selenium script tests a sample to-do list app by marking couple items as done, adding a new item to the list and finally displaying the count of pending items as output.
-
-**Step 3:** Check out the [LocalMSTest.cs](https://github.com/LambdaTest/MSTest-Selenium-Sample/blob/main/src/test/LocalMSTest.cs) file for sample test case.
-
-### Configuration of Your Test Capabilities
-
-**Step 4:** In the test script, you need to update your test capabilities. In this code, we are passing browser, browser version, and operating system information, along with TestMu AI Selenium grid capabilities via capabilities object. The capabilities object in the above code are defined as:
-
-```csharp
-DesiredCapabilities capabilities = new DesiredCapabilities();
-            capabilities.SetCapability(CapabilityType.BrowserName, "Chrome");
-            capabilities.SetCapability(CapabilityType.Version, "96");
-            capabilities.SetCapability(CapabilityType.Platform, "Windows 10");
+```bash
+git clone https://github.com/LambdaTest/MSTest-Selenium-Sample && cd MSTest-Selenium-Sample
 ```
 
-**Note:** You can generate capabilities for your test requirements with the help of **[Desired Capabilitiy Generator](https://www.testmuai.com/capabilities-generator/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)**.
+Set your credentials as environment variables.
 
-### Executing The Test
+**macOS / Linux:**
 
-**Step 5:** Build the solution by clicking in **Build > Build Solution.** 
+```bash
+export LT_USERNAME="YOUR_USERNAME"
+export LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+```
 
-**Step 6:** As shown below click on **Test Explorer** on your MS Visual Studio:
+**Windows:**
 
-<img height="200" src="https://user-images.githubusercontent.com/70570645/171441281-5e3534e5-85d1-476a-a7b6-6f82b44df229.png"/>
+```bash
+set LT_USERNAME="YOUR_USERNAME"
+set LT_ACCESS_KEY="YOUR_ACCESS_KEY"
+```
 
-**Step 7:** Click on **Run** from the Test Explorer to run the sample test as shown below:
+### Run tests
 
-<img height="200" src="https://user-images.githubusercontent.com/70570645/171441574-a64c9eba-2c15-430d-bfdb-34f2e08c198f.png"/>
-
-**Executing in Linux/macOS:**
-
-```csharp
+```bash
 dotnet test MS-Test-Cross-Browser.csproj
 ```
-Your results would be displayed on the test console and on the TestMu AI Automation Dashboard.
 
-## Running Your Parallel Tests Using MSTest Testing Framework
+View results on your TestMu AI dashboard.
 
-To run parallel tests, open Visual Studio and go to **Test Explorer** and then click on **Run All** tests to execute the tests. Your results would be displayed on the test console and on the TestMu AI Automation Dashboard.
+### Local testing with TestMu AI Tunnel
 
-## Testing Locally Hosted Or Privately Hosted Projects
+To test locally hosted apps, set up the TestMu AI tunnel. OS-specific guides:
 
-You can test your locally hosted or privately hosted projects with TestMu AI Selenium grid using TestMu AI Tunnel. All you would have to do is set up an SSH tunnel using tunnel and pass toggle `tunnel = True` via desired capabilities. TestMu AI Tunnel establishes a secure SSH protocol based tunnel that allows you in testing your locally hosted or privately hosted pages, even before they are live.
+- [Local Testing on Windows](https://www.testmuai.com/support/docs/local-testing-for-windows/)
+- [Local Testing on macOS](https://www.testmuai.com/support/docs/local-testing-for-macos/)
+- [Local Testing on Linux](https://www.testmuai.com/support/docs/local-testing-for-linux/)
 
-Refer our [TestMu AI Tunnel documentation](https://www.testmuai.com/support/docs/testing-locally-hosted-pages/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample) for more information.
+Add the following to your capabilities:
 
-Here’s how you can establish TestMu AI Tunnel.
-
-Download the binary file of:
-* [TestMu AI Tunnel for Windows](https://downloads.lambdatest.com/tunnel/v3/windows/64bit/LT_Windows.zip)
-* [TestMu AI Tunnel for macOS](https://downloads.lambdatest.com/tunnel/v3/mac/64bit/LT_Mac.zip)
-* [TestMu AI Tunnel for Linux](https://downloads.lambdatest.com/tunnel/v3/linux/64bit/LT_Linux.zip)
-
-Open command prompt and navigate to the binary folder.
-
-Run the following command:
-
-```bash
-LT --user {user’s login email} --key {user’s access key}
+```js
+tunnel: true,
 ```
-So if your user name is lambdatest@example.com and key is 123456, the command would be:
 
-```bash
-LT --user lambdatest@example.com --key 123456
-```
-Once you are able to connect **TestMu AI Tunnel** successfully, you would just have to pass on tunnel capabilities in the code shown below :
+## Contributions
 
-**Tunnel Capability**
+Contributions are welcome. Open an issue to discuss your idea before submitting a pull request. When reporting bugs, include your .NET version, OS, and Visual Studio version.
 
-```java
-DesiredCapabilities capabilities = new DesiredCapabilities();        
-        capabilities.setCapability("tunnel", true);
-```
-## Additional Links
+## TestMu AI (Formerly LambdaTest) Community
 
-* [Advanced Configuration for Capabilities](https://www.testmuai.com/support/docs/selenium-automation-capabilities/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [How to test locally hosted apps](https://www.testmuai.com/support/docs/testing-locally-hosted-pages/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [How to integrate TestMu AI with CI/CD](https://www.testmuai.com/support/docs/integrations-with-ci-cd-tools/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+Connect with testers and developers in the [TestMu AI Community](https://community.testmuai.com/). Ask questions, share what you are building, and discuss best practices in test automation and DevOps.
+  
+## TestMu AI (Formerly LambdaTest) Certifications
 
-## Tutorials 📙
+Earn free [TestMu AI Certifications](https://www.testmuai.com/certifications/) for testers, developers, and QA engineers. Validate your skills in Selenium, Cypress, Playwright, Appium, Espresso and more. Industry-recognized, shareable on LinkedIn, and built by practitioners, not marketers.
 
-Check out our latest tutorials on MSTest automation testing 👇
+## Learning Resources by TestMu AI (Formerly LambdaTest)
 
-* [NUnit vs. XUnit vs. MSTest: Comparing Unit Testing Frameworks In C#](https://www.testmuai.com/blog/nunit-vs-xunit-vs-mstest/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [Selenium MSTest Tutorial: Setup Selenium WebDriver For MSTest Framework In C#](https://www.testmuai.com/blog/setting-selenium-webdriver-for-mstest/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [Most Complete MSTest Framework Tutorial Using .Net Core](https://www.testmuai.com/blog/most-complete-mstest-framework-tutorial-using-net-core-2/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [MSTest Tutorial: Parameterized Tests For Selenium Testing](https://www.testmuai.com/blog/mstest-tutorial-parameterized-tests-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [MSTest‌ ‌Tutorial:‌ ‌Running‌ ‌First‌ ‌Selenium‌ ‌Automation‌ ‌Script‌](https://www.testmuai.com/blog/mstest-tutorial-running-first-selenium-automation-script/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [MSTest Tutorial: Environment Setup For Selenium Testing](https://www.testmuai.com/blog/mstest-tutorial-environment-setup-for-selenium-testing/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
+Learn modern testing through tutorials, guides, videos, and weekly updates:
 
-For video tutorials on Selenium MSTest, please refer to our [MSTest Tutorial Playlist](https://www.youtube.com/playlist?list=PLZMWkkQEwOPlT7o9t3IN162KY3eG7K7TN). ▶️
+* [TestMu AI Blog](https://www.testmuai.com/blog/)
+* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/)
+* [TestMu AI on YouTube](https://www.youtube.com/@TestMuAI)
+* [TestMu AI Newsletter](https://www.testmuai.com/newsletter/)
+  
+## LambdaTest is Now TestMu AI
 
-Subscribe To Our [TestMu AI YouTube Channel 🔔](https://www.youtube.com/@TestMuAI) and keep up-to-date on the latest video tutorial around software testing world.
+On **January 12, 2026**, [LambdaTest evolved to TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/), the world's first fully autonomous **Agentic AI Quality Engineering Platform**.
 
-## Documentation & Resources :books:
+Same team. Same infrastructure. Same customer accounts. All existing LambdaTest logins, scripts, capabilities, and integrations continue to work without change.
 
-      
-Visit the following links to learn more about TestMu AI's features, setup and tutorials around test automation, mobile app testing, responsive testing, and manual testing.
+👉 Find the new home for [LambdaTest](https://www.testmuai.com).
 
-* [TestMu AI Documentation](https://www.testmuai.com/support/docs/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [TestMu AI Blog](https://www.testmuai.com/blog/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)
-* [TestMu AI Learning Hub](https://www.testmuai.com/learning-hub/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample)    
+### How LambdaTest Evolved into TestMu AI
 
-## TestMu AI Community :busts_in_silhouette:
+In 2017, we launched LambdaTest with a simple mission: make testing fast, reliable, and accessible. As LambdaTest grew, we expanded into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the full depth of the testing lifecycle.
 
-The [TestMu AI Community](https://community.testmuai.com/?utm_source=github&utm_medium=repo&utm_campaign=MSTest-Selenium-Sample) allows people to interact with tech enthusiasts. Connect, ask questions, and learn from tech-savvy people. Discuss best practises in web development, testing, and DevOps with professionals from across the globe 🌎
+As software development entered the AI era, testing had to evolve, too. We rebuilt the architecture to be AI-native from the ground up, with autonomous agents that **plan, author, execute, analyze, and optimize tests** while keeping humans in the loop. The platform integrates with your repos, CI, IDEs, and terminals, continuously learning from every code change and development signal.
 
-## What's New At TestMu AI ❓
+That evolution earned a new name: **TestMu AI**, built for an AI-first future of quality engineering. TestMu is not a new name for us. It is the name of our annual community conference, which has brought together 100,000+ quality engineers to discuss how AI would reshape testing, long before that became an industry norm. 
 
-To stay updated with the latest features and product add-ons, visit [Changelog](https://changelog.lambdatest.com/)
+What started as a high-performance cloud testing platform has transformed into an AI-native, multi-agent system powering a connected, end-to-end quality layer. That evolution defined a new identity: LambdaTest evolved into TestMu AI, built for an AI-first future of quality engineering.
 
-## 🚀 LambdaTest is Now TestMu AI
+## Support
 
-👋 Welcome to TestMu AI, the next evolution of LambdaTest. As of January 2026, [LambdaTest is Now TestMu AI](https://www.testmuai.com/lambdatest-is-now-testmuai/) - we have evolved from a cross-browser testing cloud into a unified, AI-native quality engineering platform designed for the modern DevOps era.
-
-Whether you have been part of the LambdaTest community for years or are just discovering TestMu AI, our mission remains the same: to help you ship faster with high-scale test execution, autonomous testing, and deep quality analytics.
-
-### 🔄 Our Rebrand Journey
-
-In 2017, we introduced LambdaTest with a clear mission: to become the world's most trusted cloud testing platform. We built a scalable, high-performance test cloud that eliminated flakiness, improved developer feedback cycles, and accelerated release velocity for teams worldwide.
-
-As LambdaTest grew, we expanded the platform into Test Intelligence, Visual Regression Testing, Accessibility Testing, API Testing, and Performance Testing, covering the entire testing lifecycle. These capabilities enabled teams to test any stack, on any technology, at enterprise scale.
-
-Over time, we rebuilt the architecture to be AI-native from the ground up. What began as LambdaTest's high-performance testing cloud has now evolved into TestMu AI, an AI-native, multi-agent platform redefining modern quality engineering.
-
-We chose the name TestMu AI to reflect our shift towards intelligent, autonomous testing. While our identity has changed, our core technology and commitment to the testing community stay the same.
-
-👉 Find [LambdaTest's New Home](https://www.testmuai.com/).
-
-### 🔭 Explore TestMu AI
-
-The same infrastructure LambdaTest customers relied on, now delivered through autonomous AI agents.
-
-- [KaneAI](https://www.testmuai.com/kane-ai/)
-- [Agent-to-Agent Testing](https://www.testmuai.com/agent-to-agent-testing/)
-- [HyperExecute](https://www.testmuai.com/hyperexecute/)
-- [Real Device Cloud](https://www.testmuai.com/real-device-cloud/)
-- [Pricing](https://www.testmuai.com/pricing/)
-- [Documentation](https://www.testmuai.com/support/docs/)
+Got a question? Email [support@testmuai.com](mailto:support@testmuai.com) or chat with us 24x7 from our chat portal.


### PR DESCRIPTION
## Summary

- Updated README to reflect LambdaTest to TestMu AI rebrand (January 2026)
- H1 heading updated to [Title] - TestMu AI (Formerly LambdaTest)
- Replaced LambdaTest with TestMu AI in all prose (skipping GitHub org URLs, package names, config file names, code blocks, and service subdomains)
- Community URL updated to community.testmuai.com
- YouTube channel updated to youtube.com/@TestMuAI
- Support email updated to support@testmuai.com
- Added rebrand section: LambdaTest is Now TestMu AI

Generated with Claude Code